### PR TITLE
1.4.7

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,166 +4,177 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com).
 
 
+### 1.4.7 - 2022-01-12
+
+#### Changed
+-Specify border for modal dismiss button for themes that might try to add a border.
+-Add .button class to the password reset submit button so it's more likely to pick up the button style from the theme.
+
+#### Fixed
+-Fixed the cpt_is_client() function for users with no roles.
+-Fixed the modal dismiss button when there are more than two modals on the page.
+
+
 ### 1.4.6 - 2022-01-01
 
 #### Fixed
-- Fixed a JS error when the page is not a client page.
+-Fixed a JS error when the page is not a client page.
 
 
 ### 1.4.5 - 2021-12-31
 
 #### Changed
-- Added nofollow to the login modal links.
+-Added nofollow to the login modal links.
 
 #### Fixed
-- Fixed a PHP error when the page does not have an ID.
+-Fixed a PHP error when the page does not have an ID.
 
 
 ### 1.4.4 - 2021-12-28
 
 #### Changed
-- Clarified the additional status update request notification instructions on the settings page.
-- Clarified the new client account activation email message body instructions on the settings page.
-- Don't know messages on client profiles in the admin if messaging is disabled.
+-Clarified the additional status update request notification instructions on the settings page.
+-Clarified the new client account activation email message body instructions on the settings page.
+-Don't know messages on client profiles in the admin if messaging is disabled.
 
 
 ### 1.4.3 - 2021-10-08
 
 #### Added
-- Message links in the admin message list now go to the page on which the message appears.
+-Message links in the admin message list now go to the page on which the message appears.
 
 
 ### 1.4.2 - 2021-06-06
 
 #### Changed
-- Removed jQuery from cpt-admin.js.
-- Removed jQuery from cpt-frontend.js.
+-Removed jQuery from cpt-admin.js.
+-Removed jQuery from cpt-frontend.js.
 
 
 ### 1.4.1 - 2021-02-12
 
 #### Added
-- Added a wrapper for the status request update button.
+-Added a wrapper for the status request update button.
 
 
 ### 1.4 - 2021-01-12
 
 #### Added
-- NEW MODULE: Knowledge Base! The knowledge base is a restricted page you can use to share information and resources with your clients. Add as many sub-pages as you like; they will be nicely organized in an index for your clients.
-- Client dashboard pages now have navigation tabs, including breadcrumbs and a drop-down index to help clients navigate your knowledge base.
+-NEW MODULE: Knowledge Base! The knowledge base is a restricted page you can use to share information and resources with your clients. Add as many sub-pages as you like; they will be nicely organized in an index for your clients.
+-Client dashboard pages now have navigation tabs, including breadcrumbs and a drop-down index to help clients navigate your knowledge base.
 
 #### Changed
-- The settings page is better organized, with general/core settings, then settings for each module.
-- Each of the non-core modules can be disabled. Currently the non-core modules are the Status Update Request Button, Messaging, and Knowledge Base.
-- You can now add content to the main client dashboard page, which will be shown below the welcome message and status update request button (if it is enabled).
+-The settings page is better organized, with general/core settings, then settings for each module.
+-Each of the non-core modules can be disabled. Currently the non-core modules are the Status Update Request Button, Messaging, and Knowledge Base.
+-You can now add content to the main client dashboard page, which will be shown below the welcome message and status update request button (if it is enabled).
 
 #### Fixed
-- Untitled messages no longer show "Untitled" as the title.
+-Untitled messages no longer show "Untitled" as the title.
 
 
 ### 1.3.1 - 2020-12-18
 
 #### Added
-- Welcome message.
+-Welcome message.
 
 #### Changed
-- Only show the SSL warning on CPT admin pages.
+-Only show the SSL warning on CPT admin pages.
 
 
 ### 1.3 - 2020-11-24
 
 #### Added
-- Client managers can now be added and removed from the new **Managers** submenu, and are also shown in the client list and client profile. As you can when adding a client, you can add a new or existing WordPress user.
-- Assign a default client manager in the settings.
-- Filter the client list by clients assigned to you ("Mine").
+-Client managers can now be added and removed from the new **Managers** submenu, and are also shown in the client list and client profile. As you can when adding a client, you can add a new or existing WordPress user.
+-Assign a default client manager in the settings.
+-Filter the client list by clients assigned to you ("Mine").
 
 #### Changed
-- The add-client form is now on the Clients page.
-- Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
-- New client emails will now come from the client manager instead of a default name and email address.
-- Update the element expander script so it can handle multiple expanders on the same page. Also, form elements within an expander with data-required="true" will have the required attributes removed when hidden.
-- Make cpt_get_notices() easier to use by changing the argument to an array so it only needs to be called once.
+-The add-client form is now on the Clients page.
+-Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
+-New client emails will now come from the client manager instead of a default name and email address.
+-Update the element expander script so it can handle multiple expanders on the same page. Also, form elements within an expander with data-required="true" will have the required attributes removed when hidden.
+-Make cpt_get_notices() easier to use by changing the argument to an array so it only needs to be called once.
 
 #### Fixed
-- The standard login form no longer redirects to a blank page when a redirect is present.
+-The standard login form no longer redirects to a blank page when a redirect is present.
 
 
 ### 1.2.1 - 2020-10-24
 
 #### Fixed
-- Adding an existing user as a client now works as it should.
+-Adding an existing user as a client now works as it should.
 
 
 ### 1.2 - 2020-10-23
 
 #### Added
-- Setting to disable the status request button entirely.
-- Setting to change the default email behavior to include the full message, rather than just a notification.
-- Override the default email behavior on individual messages.
+-Setting to disable the status request button entirely.
+-Setting to change the default email behavior to include the full message, rather than just a notification.
+-Override the default email behavior on individual messages.
 
 #### Changed
-- Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.
+-Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.
 
 
 ### 1.1 - 2020-10-20
 
 #### Added
-- Delete a client from the client's profile page, under **Edit Client**.
+-Delete a client from the client's profile page, under **Edit Client**.
 
 
 ### 1.0.5 - 2020-10-07
 
 #### Changed
-- Handle frontend login error on the front end.
-- General tidying up.
+-Handle frontend login error on the front end.
+-General tidying up.
 
 #### Removed
-- Remove unused capabilities from Client Manager role (for now).
-- Remove unused functions cpt_get_client_profile_link and cpt_get_client_id.
+-Remove unused capabilities from Client Manager role (for now).
+-Remove unused functions cpt_get_client_profile_link and cpt_get_client_id.
 
 #### Fixed
-- Email notifications should now deliver with the intended formatting.
+-Email notifications should now deliver with the intended formatting.
 
 
 ### 1.0.4 - 2020-10-05
 
 #### Fixed
-- Prevent not-logged-in messages from displaying in the head when the_content filter is called (by Yoast SEO, for example).
+-Prevent not-logged-in messages from displaying in the head when the_content filter is called (by Yoast SEO, for example).
 
 
 ### 1.0.3 - 2020-10-05
 
 #### Fixed
-- Center the modal dismiss button.
-- Fix false negatives from cpt_is_client if the user is not logged in but the user ID is provided.
-- Prevent Client Power Tools from intercepting the password reset workflow for non-clients.
+-Center the modal dismiss button.
+-Fix false negatives from cpt_is_client if the user is not logged in but the user ID is provided.
+-Prevent Client Power Tools from intercepting the password reset workflow for non-clients.
 
 
 ### 1.0.2 - 2020-10-02
 
 #### Fixed
-- Fixed URL encoding.
+-Fixed URL encoding.
 
 
 ### 1.0.1 - 2020-10-02
 
 #### Fixed
-- Check for main query on client dashboard.
-- Fixed set/change password key sanitization.
+-Check for main query on client dashboard.
+-Fixed set/change password key sanitization.
 
 
 ### 1.0 - 2020-10-02
 
 #### Added
-- Added some frontend form styles for greater compatibility with different themes.
+-Added some frontend form styles for greater compatibility with different themes.
 
 #### Changed
-- Override default button display style on dismiss button.
-- Change constant prefix from CPT_ to CLIENT_POWER_TOOLS_.
-- Data sanitization and validation.
+-Override default button display style on dismiss button.
+-Change constant prefix from CPT_ to CLIENT_POWER_TOOLS_.
+-Data sanitization and validation.
 
 
 ### 0.1 (Beta) - 2020-09-23
 
 #### Added
-- Everything.
+-Everything.

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -4,7 +4,7 @@
 Plugin Name:	Client Power Tools
 Plugin URI:		https://clientpowertools.com
 Description:	Client Power Tools is an easy-to-use private client dashboard and communication portal built for independent contractors, consultants, lawyers, and other professionals.
-Version:			1.4.6
+Version:			1.4.7
 Author:				Sam Glover
 Author URI:		https://samglover.net
 Text Domain:	client-power-tools
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * Constants
  */
-define( 'CLIENT_POWER_TOOLS_PLUGIN_VERSION', '1.4.6' );
+define( 'CLIENT_POWER_TOOLS_PLUGIN_VERSION', '1.4.7' );
 define( 'CLIENT_POWER_TOOLS_DIR_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CLIENT_POWER_TOOLS_DIR_URL', plugin_dir_url( __FILE__ ) );
 

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -51,7 +51,7 @@ function cpt_is_client( $user_id = null ) {
 
   $user = get_userdata( $user_id );
 
-  if ( in_array( 'cpt-client', $user->roles ) ) {
+  if ( $user->roles && in_array( 'cpt-client', $user->roles ) ) {
     return true;
   } else {
     return false;

--- a/frontend/cpt-frontend.css
+++ b/frontend/cpt-frontend.css
@@ -150,6 +150,7 @@
   .cpt-inline-modal .cpt-notice-dismiss-button {
     align-items: center;
     background-color: #ccc;
+    border: 1px solid #bbb;
     border-radius: 50%;
     cursor: pointer;
     display: flex;
@@ -178,6 +179,7 @@
   .cpt-modal .cpt-notice-dismiss-button:hover,
   .cpt-inline-modal .cpt-notice-dismiss-button:hover {
     background-color: #ddd;
+    border-color: #ccc;
     box-shadow: 1px 1px 3px rgba( 0, 0, 0, 0.4 );
     text-decoration: none;
   }
@@ -186,6 +188,7 @@
   .cpt-modal .cpt-notice-dismiss-button:active,
   .cpt-inline-modal .cpt-notice-dismiss-button:active {
     background-color: #bbb;
+    border-color: #bbb;
     box-shadow: none;
     text-decoration: none;
   }

--- a/frontend/cpt-frontend.js
+++ b/frontend/cpt-frontend.js
@@ -4,9 +4,8 @@ let postID        = cpt_frontend_js_vars.postID;
 let dashboardID   = cpt_frontend_js_vars.dashboardID;
 
 // Modal Classes
-let cptModal      = document.querySelector( '.cpt-modal' );
+let cptModal      = document.querySelectorAll( '.cpt-modal' );
 let modalScreen   = document.querySelector( '.cpt-modal-screen' );
-let modalDismiss  = document.querySelector( '.cpt-modal-dismiss-button' );
 
 // Login Modal
 let loginLink     = document.querySelectorAll( '.cpt-login-link' );
@@ -73,29 +72,44 @@ function showResetPW() {
 
 }
 
+if ( cptModal ) {
 
-modalDismiss.addEventListener( 'click', function() {
+  let i = 0;
 
-  cptModal.style.display = 'none';
-  modalScreen.style.display = 'none';
+  cptModal.forEach( function( e ) {
 
-  /**
-  * Removes the cpt_login, cpt_notice, and password set/reset query parameters
-  * from the URL just in case the user tries to bookmark it or copy and paste
-  * some reason.
-  */
-  params.delete( 'cpt_login' );
-  params.delete( 'cpt_notice' );
-  params.delete( 'key' );
-  params.delete( 'login' );
+    let modal = cptModal[i];
 
-  if ( params.toString().length > 0 ) {
-    history.replaceState( {}, '', baseURL + '?' + params );
-  } else {
-    history.replaceState( {}, '', baseURL );
-  }
+    cptModal[i].querySelector( '.cpt-modal-dismiss-button' ).addEventListener( 'click', function( e ) {
 
-});
+      e.preventDefault();
+
+      modal.style.display = 'none';
+      modalScreen.style.display = 'none';
+
+      /**
+      * Removes the cpt_login, cpt_notice, and password set/reset query parameters
+      * from the URL just in case the user tries to bookmark it or copy and paste
+      * some reason.
+      */
+      params.delete( 'cpt_login' );
+      params.delete( 'cpt_notice' );
+      params.delete( 'key' );
+      params.delete( 'login' );
+
+      if ( params.toString().length > 0 ) {
+        history.replaceState( {}, '', baseURL + '?' + params );
+      } else {
+        history.replaceState( {}, '', baseURL );
+      }
+
+    });
+
+    i++;
+
+  });
+
+}
 
 
 if ( loginLink ) {

--- a/frontend/cpt-frontend.php
+++ b/frontend/cpt-frontend.php
@@ -160,10 +160,10 @@ function cpt_login() {
                     <form id="lostpasswordform" action="<?php echo $cpt_lostpassword_url; ?>" method="post">
                       <p>
                         <label for="user_login"><?php _e( 'Email' ); ?></label>
-                        <input type="text" name="user_login" id="user_login">
+                        <input type="text" name="user_login" id="lostpassword_user_login">
                       </p>
                       <p class="submit">
-                        <input type="submit" name="submit" class="lostpassword-button" value="<?php _e( 'Reset Password' ); ?>"/>
+                        <input type="submit" name="submit" class="lostpassword-button button" value="<?php _e( 'Reset Password' ); ?>"/>
                       </p>
                     </form>
                     <p><small><a id="cpt-login-go-to-login" href="cpt-login-modal-login" rel="nofollow"><?php _e( 'Back to Login' ); ?></a></small></p>

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,17 @@ For more information on how to take advantage of the new and updated features, p
 
 == Changelog ==
 
+### 1.4.7 - 2022-01-12
+
+#### Changed
+-Specify border for modal dismiss button for themes that might try to add a border.
+-Add .button class to the password reset submit button so it's more likely to pick up the button style from the theme.
+
+#### Fixed
+-Fixed the cpt_is_client() function for users with no roles.
+-Fixed the modal dismiss button when there are more than two modals on the page.
+
+
 ### 1.4.6 - 2022-01-01
 
 #### Fixed


### PR DESCRIPTION
#### Changed
-Specify border for modal dismiss button for themes that might try to add a border.
-Add .button class to the password reset submit button so it's more likely to pick up the button style from the theme.

#### Fixed
-Fixed the cpt_is_client() function for users with no roles.
-Fixed the modal dismiss button when there are more than two modals on the page.