### PR TITLE
1.8.6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+### 1.8.6 - 2024-08-25
+
+#### Fixed
+- Fixed a bug in cpt_messages() where calling get_the_ID() after cpt_messages() would return the last message ID instead of the main post ID.
+- Fixed a bug in cpt_get_notices() where WordPress would add a second, unstyled dismiss button to notices on the frontend.
+
+
 ### 1.8.5 - 2024-06-09
 
 #### Changed

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -4,7 +4,7 @@
  * Plugin Name: Client Power Tools
  * Plugin URI: https://clientpowertools.com
  * Description: Client Power Tools is an easy-to-use client dashboard, project management, and communication portal built for designers, developers, consultants, lawyers, and other professionals.
- * Version: 1.8.5
+ * Version: 1.8.6
  * Author: Sam Glover
  * Author URI: https://samglover.net
  * Text Domain: client-power-tools
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) exit;
 /**
  * Constants
  */
-define('CLIENT_POWER_TOOLS_PLUGIN_VERSION', '1.8.5');
+define('CLIENT_POWER_TOOLS_PLUGIN_VERSION', '1.8.6');
 define('CLIENT_POWER_TOOLS_DIR_PATH', plugin_dir_path(__FILE__));
 define('CLIENT_POWER_TOOLS_DIR_URL', plugin_dir_url(__FILE__));
 

--- a/common/cpt-common-messages.php
+++ b/common/cpt-common-messages.php
@@ -87,6 +87,7 @@ function cpt_message_list($clients_user_id) {
   else:
     printf(__('%sNo messages found.%s' , 'client-power-tools'), '<p>', '</p>');
   endif;
+  wp_reset_postdata();
 }
 
 

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -258,10 +258,12 @@ function cpt_get_notices() {
   if (!$notice) return;
 
   $classes = [
-    'notice',
     'cpt-notice',
-    'is-dismissible',
   ];
+  if (is_admin()) {
+    $classes[] = 'notice';
+    $classes[] = 'is-dismissible';
+  }
   if (!is_admin()) {
     $classes[] = 'card';
     $classes[] = 'visible';

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: samglover
 Tags: client management, project management, portal, restrict content, frontend login
 Requires at least: 5.5
-Tested up to: 6.6
+Tested up to: 6.6.1
 Requires PHP: 7.3.5
 Stable tag: trunk
 License: GPLv3
@@ -108,6 +108,13 @@ For more information on how to take advantage of the new and updated features, s
 
 
 == Changelog ==
+
+### 1.8.6 - 2024-08-25
+
+#### Fixed
+- Fixed a bug in cpt_messages() where calling get_the_ID() after cpt_messages() would return the last message ID instead of the main post ID.
+- Fixed a bug in cpt_get_notices() where WordPress would add a second, unstyled dismiss button to notices on the frontend.
+
 
 ### 1.8.5 - 2024-06-09
 


### PR DESCRIPTION
#### Fixed
- Fixed a bug in cpt_messages() where calling get_the_ID() after cpt_messages() would return the last message ID instead of the main post ID.
- Fixed a bug in cpt_get_notices() where WordPress would add a second, unstyled dismiss button to notices on the frontend.